### PR TITLE
fixed closing tag for <alert>

### DIFF
--- a/pretext.lua
+++ b/pretext.lua
@@ -144,7 +144,7 @@ end
 
 -- No <smallcaps> in PreTeXt.  <alert> can be searched for and changed case-by-case.
 function SmallCaps(s)
-  return '<alert>' .. s .. '<alert>'
+  return '<alert>' .. s .. '</alert>'
 end
 
 -- could also be "gone"


### PR DESCRIPTION
Oops, the `<alert>` tag in `function SmallCaps(s)` was being generated with another opening tag instead of a closing tag.